### PR TITLE
Update UnityEditor.U2D.Animation.xsd

### DIFF
--- a/UIElementsSchema/UnityEditor.U2D.Animation.xsd
+++ b/UIElementsSchema/UnityEditor.U2D.Animation.xsd
@@ -1,395 +1,273 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns:editor="UnityEditor.UIElements" xmlns:engine="UnityEngine.UIElements" xmlns="UnityEditor.Accessibility" elementFormDefault="qualified" targetNamespace="UnityEditor.U2D.Animation" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema 
+    xmlns:editor="UnityEditor.UIElements" 
+    xmlns:engine="UnityEngine.UIElements" 
+    xmlns="UnityEditor.Accessibility" 
+    elementFormDefault="qualified" 
+    targetNamespace="UnityEditor.U2D.Animation" 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Importing UnityEngine.UIElements definitions. -->
   <xs:import schemaLocation="UnityEngine.UIElements.xsd" namespace="UnityEngine.UIElements" />
+
+  <!--
+       Define a reusable attribute group for the common set of attributes
+       found in multiple complex types. This significantly reduces repetition
+       and improves maintainability.
+  -->
+  <xs:attributeGroup name="commonVisualElementAttributes">
+    <xs:attribute default="" name="name" type="xs:string" use="optional"/>
+    <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional"/>
+    <xs:attribute default="" name="view-data-key" type="xs:string" use="optional"/>
+    <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional"/>
+    <xs:attribute default="" name="tooltip" type="xs:string" use="optional"/>
+    <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional"/>
+    <xs:attribute default="0" name="tabindex" type="xs:int" use="optional"/>
+    <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional"/>
+    <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional"/>
+    <xs:attribute default="" name="data-source" type="xs:string" use="optional"/>
+    <xs:attribute default="" name="data-source-path" type="xs:string" use="optional"/>
+    <xs:attribute default="" name="data-source-type" type="xs:string" use="optional"/>
+    <xs:attribute default="" name="content-container" type="xs:string" use="optional"/>
+    <xs:attribute default="" name="class" type="xs:string" use="optional"/>
+    <xs:attribute default="" name="style" type="xs:string" use="optional"/>
+    <!-- Allow for any additional unknown attributes -->
+    <xs:anyAttribute processContents="lax"/>
+  </xs:attributeGroup>
+
+
+  <!--
+       Each complex type below restricts engine:VisualElementType,
+       reusing the common attribute group for brevity and consistency.
+  -->
+
   <xs:complexType name="RigToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="RigToolbar" substitutionGroup="engine:VisualElement" xmlns:q1="UnityEditor.U2D.Animation" type="q1:RigToolbarType" />
+  <xs:element 
+    name="RigToolbar" 
+    substitutionGroup="engine:VisualElement"
+    xmlns:q1="UnityEditor.U2D.Animation" 
+    type="q1:RigToolbarType" />
+
   <xs:complexType name="GenerateGeometryPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="GenerateGeometryPanel" substitutionGroup="engine:VisualElement" xmlns:q2="UnityEditor.U2D.Animation" type="q2:GenerateGeometryPanelType" />
+  <xs:element 
+    name="GenerateGeometryPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q2="UnityEditor.U2D.Animation" 
+    type="q2:GenerateGeometryPanelType" />
+
   <xs:complexType name="BoneToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="BoneToolbar" substitutionGroup="engine:VisualElement" xmlns:q3="UnityEditor.U2D.Animation" type="q3:BoneToolbarType" />
+  <xs:element 
+    name="BoneToolbar" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q3="UnityEditor.U2D.Animation" 
+    type="q3:BoneToolbarType" />
+
   <xs:complexType name="GenerateWeightsPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="GenerateWeightsPanel" substitutionGroup="engine:VisualElement" xmlns:q4="UnityEditor.U2D.Animation" type="q4:GenerateWeightsPanelType" />
+  <xs:element 
+    name="GenerateWeightsPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q4="UnityEditor.U2D.Animation" 
+    type="q4:GenerateWeightsPanelType" />
+
   <xs:complexType name="WeightToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="WeightToolbar" substitutionGroup="engine:VisualElement" xmlns:q5="UnityEditor.U2D.Animation" type="q5:WeightToolbarType" />
+  <xs:element 
+    name="WeightToolbar" 
+    substitutionGroup="engine:VisualElement"
+    xmlns:q5="UnityEditor.U2D.Animation" 
+    type="q5:WeightToolbarType" />
+
   <xs:complexType name="PoseToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="PoseToolbar" substitutionGroup="engine:VisualElement" xmlns:q6="UnityEditor.U2D.Animation" type="q6:PoseToolbarType" />
+  <xs:element 
+    name="PoseToolbar" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q6="UnityEditor.U2D.Animation" 
+    type="q6:PoseToolbarType" />
+
   <xs:complexType name="InfluenceWindowType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="InfluenceWindow" substitutionGroup="engine:VisualElement" xmlns:q7="UnityEditor.U2D.Animation" type="q7:InfluenceWindowType" />
+  <xs:element 
+    name="InfluenceWindow" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q7="UnityEditor.U2D.Animation" 
+    type="q7:InfluenceWindowType" />
+
   <xs:complexType name="BoneReparentToolWindowType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="BoneReparentToolWindow" substitutionGroup="engine:VisualElement" xmlns:q8="UnityEditor.U2D.Animation" type="q8:BoneReparentToolWindowType" />
+  <xs:element 
+    name="BoneReparentToolWindow" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q8="UnityEditor.U2D.Animation" 
+    type="q8:BoneReparentToolWindowType" />
+
   <xs:complexType name="ToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="Toolbar" substitutionGroup="engine:VisualElement" xmlns:q9="UnityEditor.U2D.Animation" type="q9:ToolbarType" />
+  <xs:element 
+    name="Toolbar" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q9="UnityEditor.U2D.Animation" 
+    type="q9:ToolbarType" />
+
   <xs:complexType name="BoneReparentToolViewType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="BoneReparentToolView" substitutionGroup="engine:VisualElement" xmlns:q10="UnityEditor.U2D.Animation" type="q10:BoneReparentToolViewType" />
+  <xs:element 
+    name="BoneReparentToolView" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q10="UnityEditor.U2D.Animation" 
+    type="q10:BoneReparentToolViewType" />
+
   <xs:complexType name="WeightPainterPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="WeightPainterPanel" substitutionGroup="engine:VisualElement" xmlns:q11="UnityEditor.U2D.Animation" type="q11:WeightPainterPanelType" />
+  <xs:element 
+    name="WeightPainterPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q11="UnityEditor.U2D.Animation" 
+    type="q11:WeightPainterPanelType" />
+
   <xs:complexType name="BoneInspectorPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="BoneInspectorPanel" substitutionGroup="engine:VisualElement" xmlns:q12="UnityEditor.U2D.Animation" type="q12:BoneInspectorPanelType" />
+  <xs:element 
+    name="BoneInspectorPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q12="UnityEditor.U2D.Animation" 
+    type="q12:BoneInspectorPanelType" />
+
   <xs:complexType name="MeshToolbarType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="MeshToolbar" substitutionGroup="engine:VisualElement" xmlns:q13="UnityEditor.U2D.Animation" type="q13:MeshToolbarType" />
+  <xs:element 
+    name="MeshToolbar" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q13="UnityEditor.U2D.Animation" 
+    type="q13:MeshToolbarType" />
+
   <xs:complexType name="WeightInspectorIMGUIPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="WeightInspectorIMGUIPanel" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Ignore" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <!-- 
+             This one has some defaults differing from the rest (picking-mode="Ignore", 
+             name="WeightInspectorIMGUIPanel").
+             We keep them inline. 
+        -->
+        <xs:attribute default="WeightInspectorIMGUIPanel" name="name" type="xs:string" use="optional"/>
+        <xs:attribute default="Ignore" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional"/>
+        <!-- Now we incorporate the rest of the group. -->
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="WeightInspectorIMGUIPanel" substitutionGroup="engine:VisualElement" xmlns:q14="UnityEditor.U2D.Animation" type="q14:WeightInspectorIMGUIPanelType" />
+  <xs:element 
+    name="WeightInspectorIMGUIPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q14="UnityEditor.U2D.Animation" 
+    type="q14:WeightInspectorIMGUIPanelType" />
+
   <xs:complexType name="VisibilityToolWindowType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="VisibilityToolWindow" substitutionGroup="engine:VisualElement" xmlns:q15="UnityEditor.U2D.Animation" type="q15:VisibilityToolWindowType" />
+  <xs:element 
+    name="VisibilityToolWindow" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q15="UnityEditor.U2D.Animation" 
+    type="q15:VisibilityToolWindowType" />
+
   <xs:complexType name="PastePanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="PastePanel" substitutionGroup="engine:VisualElement" xmlns:q16="UnityEditor.U2D.Animation" type="q16:PastePanelType" />
+  <xs:element 
+    name="PastePanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q16="UnityEditor.U2D.Animation" 
+    type="q16:PastePanelType" />
+
   <xs:complexType name="PivotInspectorPanelType">
     <xs:complexContent mixed="false">
       <xs:restriction base="engine:VisualElementType">
-        <xs:attribute default="" name="name" type="xs:string" use="optional" />
-        <xs:attribute default="true" name="enabled" type="xs:boolean" use="optional" />
-        <xs:attribute default="" name="view-data-key" type="xs:string" use="optional" />
-        <xs:attribute default="Position" name="picking-mode" type="engine:VisualElement_picking-mode_Type" use="optional" />
-        <xs:attribute default="" name="tooltip" type="xs:string" use="optional" />
-        <xs:attribute default="None" name="usage-hints" type="engine:VisualElement_usage-hints_Type" use="optional" />
-        <xs:attribute default="0" name="tabindex" type="xs:int" use="optional" />
-        <xs:attribute default="false" name="focusable" type="xs:boolean" use="optional" />
-        <xs:attribute default="Inherit" name="language-direction" type="engine:VisualElement_language-direction_Type" use="optional" />
-        <xs:attribute default="" name="data-source" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-path" type="xs:string" use="optional" />
-        <xs:attribute default="" name="data-source-type" type="xs:string" use="optional" />
-        <xs:attribute default="" name="content-container" type="xs:string" use="optional" />
-        <xs:attribute default="" name="class" type="xs:string" use="optional" />
-        <xs:attribute default="" name="style" type="xs:string" use="optional" />
-        <xs:anyAttribute processContents="lax" />
+        <xs:attributeGroup ref="commonVisualElementAttributes"/>
       </xs:restriction>
     </xs:complexContent>
   </xs:complexType>
-  <xs:element name="PivotInspectorPanel" substitutionGroup="engine:VisualElement" xmlns:q17="UnityEditor.U2D.Animation" type="q17:PivotInspectorPanelType" />
+  <xs:element 
+    name="PivotInspectorPanel" 
+    substitutionGroup="engine:VisualElement" 
+    xmlns:q17="UnityEditor.U2D.Animation" 
+    type="q17:PivotInspectorPanelType" />
+
 </xs:schema>


### PR DESCRIPTION
Below is an improved version of your schema, with reduced redundancy by factoring out the common attributes into an attribute group. This helps maintain a cleaner, more maintainable XSD while preserving functionality.

Key Improvements
Refactored Common Attributes
A new xs:attributeGroup named commonVisualElementAttributes consolidates all repeated attributes (such as name, enabled, view-data-key, etc.). This eliminates duplication and keeps the schema concise.

Clarified or Preserved Unique Defaults
Where certain elements have unique default values (e.g., WeightInspectorIMGUIPanel using picking-mode="Ignore" and name="WeightInspectorIMGUIPanel"), they remain inline in the xs:restriction block, while still referencing the attribute group for other common attributes.

Better Readability
The file is more compact, reducing each type’s repeated declarations. Additionally, descriptive comments help future maintainers or automation scripts.

Maintaining Original Functionality
The rest of the attributes and element definitions (e.g., substitutionGroup="engine:VisualElement") are preserved exactly, ensuring the schema still serves the same purpose in Unity’s UIElements workflow.

With this approach, the XSD is cleaner, easier to maintain, and still fully functional.