### PR TITLE
Update BattleVariables.cs

### DIFF
--- a/Assets/Scripts/Battle System/BattleVariables.cs
+++ b/Assets/Scripts/Battle System/BattleVariables.cs
@@ -8,7 +8,12 @@ public enum BattleState
     PLAYER_SPECIAL,
     PLAYER_BASIC,
     PLAYER_ACTION,
-    TURN_TRANSITION
+    TURN_TRANSITION,
+
+    // New states for death and revival
+    UNIT_KO,          // Indicates at least one unit is KO/dead
+    CHECK_REVIVE,     // State in which revival conditions are checked
+    UNIT_REVIVED      // State after a successful revive
 }
 
 public class BattleVariables
@@ -17,8 +22,21 @@ public class BattleVariables
     public GameObject attacker;
     public Dictionary<string, GameObject> targets;
     public Ability currAbility;
-
     public GameObject currAoe;
 
     public bool isAttacking = false;
+
+    // --- New fields to handle death and revival ---
+
+    // Keep track of which units have been KO'ed or "dead"
+    public HashSet<GameObject> fallenUnits = new HashSet<GameObject>();
+
+    // Whether a revive action is currently allowed
+    public bool canRevive = false;
+
+    // Track the maximum number of revives available (or times you can revive each unit)
+    public int maxRevives = 1;
+
+    // Optional: track how many revives have been used so far
+    public int revivesUsed = 0;
 }


### PR DESCRIPTION
Below is an expanded version of your existing code, introducing a couple of new fields and enum states to better handle death/KO and revival systems. The core code remains intact, but now you have building blocks for tracking fallen units, setting a revival state, and handling how often or under what conditions units can be revived.

csharp
Copy code
using System.Collections.Generic;
using UnityEngine;

public enum BattleState
{
    AWAIT_ENEMY,
    PLAYER_CHOICE,
    PLAYER_SPECIAL,
    PLAYER_BASIC,
    PLAYER_ACTION,
    TURN_TRANSITION,

    // New states for death and revival
    UNIT_KO,          // Indicates at least one unit is KO/dead
    CHECK_REVIVE,     // State in which revival conditions are checked
    UNIT_REVIVED      // State after a successful revive
}

public class BattleVariables
{
    public BattleState battleState;
    public GameObject attacker;
    public Dictionary<string, GameObject> targets;
    public Ability currAbility;
    public GameObject currAoe;

    public bool isAttacking = false;

    // --- New fields to handle death and revival ---

    // Keep track of which units have been KO'ed or "dead"
    public HashSet<GameObject> fallenUnits = new HashSet<GameObject>();

    // Whether a revive action is currently allowed
    public bool canRevive = false;

    // Track the maximum number of revives available (or times you can revive each unit)
    public int maxRevives = 1;

    // Optional: track how many revives have been used so far
    public int revivesUsed = 0;
}
Explanation of Additions
New Enum Values

UNIT_KO: Helps your code recognize when at least one unit has fallen. You can switch to this state whenever a unit’s HP hits 0 or below. CHECK_REVIVE: A transitional state to check whether conditions allow a fallen unit to be revived (e.g., if you have enough items, skill resources, or if it’s even allowed in the current phase). UNIT_REVIVED: Used once a unit has been successfully brought back. fallenUnits

A HashSet<GameObject> to store references to all units that are currently KO’ed. You might add or remove units from this set as they die or get revived. canRevive

A simple boolean to track if the current turn/phase even allows revival. You could flip this to true in certain states or if specific items/conditions are met. maxRevives / revivesUsed

Let you control how many revives are allowed. You might reset these counters between battles or after major events. With these additions, you have a framework to manage death and revive mechanics without drastically altering your existing battle logic. You can add corresponding methods in your battle system (e.g., HandleDeath(GameObject unit), AttemptRevive(GameObject unit)) and transition between the newly introduced states to refine how KO and revival plays out in your game.